### PR TITLE
Fix value of type `name` in find function.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,8 +20,8 @@ class VSMemory {
 
 	private update(statusBarItem: StatusBarItem) {
 		const config = workspace.getConfiguration('vscodemem');
-		// `Visual` is used because `Code` isnt listed
-		return find('name', 'Visual', true)
+		// `code` is used because `Visual` or `Code` isnt listed
+		return find('name', 'code', true)
 			.then((list: any[]) => {
 				const pids = list.map(item => item && item.pid);
 				pidusage(pids, (err: Error, stats: any[]) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,8 +20,14 @@ class VSMemory {
 
 	private update(statusBarItem: StatusBarItem) {
 		const config = workspace.getConfiguration('vscodemem');
-		// `code` is used because `Visual` or `Code` isnt listed
-		return find('name', 'code', true)
+		/*
+		 * `searchTerm` has been introduced, so that the extension can work on multiple platforms.
+		 *
+		 * In linux the term to be searched must be "code", in other platforms like OSX the term must be "Visual".
+		 */
+		const searchTerm = process.platform === 'linux' ? 'code' : 'Visual';
+
+		return find('name', searchTerm, true)
 			.then((list: any[]) => {
 				const pids = list.map(item => item && item.pid);
 				pidusage(pids, (err: Error, stats: any[]) => {


### PR DESCRIPTION
In `cmd` the correct value for the Visual Studio Code process is` code` and not `Visual` or `Code`.

```Shell
/opt/visual-studio-code/code --max-old-space-size = 3072 /opt/visual-studio-code/resources/app/extensions/node_modules/typescript/lib/tsserver.js --serverMode partialSemantic - -useInferredProjectPerProjectRoot --disableAutomaticTypingAcquisition --cancellationPipeName /tmp/vscode-typescript1000/57d60bf28194f7e2e4e4/tscancellation-d006b17f634438d03107.tmp* --globalPlugins typescript-code / plugin-code-plugin / codes-cod-resources / typescript-language-features --locale en --noGetErrOnBackgroundUpdate --validateDefaultNpmLocation
```
Apparently at some point the name of the executable has been changed.

After adjusting the value for the `type` parameter when it is` name`, extension working normally.

```Javascript
update(statusBarItem) {
    const config = vscode_1.workspace.getConfiguration('vscodemem');
    // `code` is used because `Visual` and `Code` isnt listed. 
    
    return find('name', 'code', true)
        .then((list) => {
        ...
        });
    });
}
```

![Captura de tela de 2021-02-18 14-33-52](https://user-images.githubusercontent.com/2080547/108400828-6d08fb80-71fa-11eb-8802-205ec507bce8.png)
